### PR TITLE
Switch to graceful-fs to avoid EMFILE

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "standard": "^5.3.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2"
+  },
+  "optionalDependencies": {
+    "graceful-fs": "^4.1.9"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,10 @@
 var assert = require('assert')
-var fs = require('fs')
+var fs
+try {
+  fs = require('graceful-fs')
+} catch (e) {
+  fs = require('fs')
+}
 var path = require('path')
 var Readable = require('stream').Readable
 var util = require('util')


### PR DESCRIPTION
graceful-fs is an optional dep; klaw uses the normal fs module if graceful-fs can't be loaded.

Fixes https://github.com/jprichardson/node-fs-extra/issues/275.