### PR TITLE
Add klaw-sync link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Name
 `klaw` is `walk` backwards :p
 
 
+Sync
+----
+
+If you need the same functionality but synchronous, you can use [klaw-sync](https://github.com/mawni/node-klaw-sync).
+
+
 Usage
 -----
 


### PR DESCRIPTION
This PR adds https://github.com/mawni/node-klaw-sync to readme. Please let me know if it is not in an appropriate section. Thanks.