### PR TITLE
Update klaw-sync link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Name
 Sync
 ----
 
-If you need the same functionality but synchronous, you can use [klaw-sync](https://github.com/mawni/node-klaw-sync).
+If you need the same functionality but synchronous, you can use [klaw-sync](https://github.com/manidlou/node-klaw-sync).
 
 
 Usage


### PR DESCRIPTION
This PR updates `klaw-sync` link in README. I changed my username from `mawni` to `manidlou`, so I updated the `klaw-sync` link to the new one https://github.com/manidlou/node-klaw-sync. Sorry for inconvenience. Thanks a lot.