### PR TITLE
Add standard-markdown & refactor README.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "File system walker with Readable stream interface.",
   "main": "./src/index.js",
   "scripts": {
-    "lint": "standard",
+    "lint": "standard && standard-markdown",
     "test": "npm run lint && npm run unit",
     "unit": "tape tests/**/*.js | tap-spec"
   },
@@ -33,6 +33,7 @@
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",
     "standard": "^10.0.2",
+    "standard-markdown": "^4.0.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.2.2"
   }


### PR DESCRIPTION
- Added [standard-markdown](https://github.com/zeke/standard-markdown) to lint `js` code blocks inside `README.md`, the same way that we use it in [fs-extra](https://github.com/jprichardson/node-fs-extra).
- Changed default `fs` to [`graceful-fs`](https://github.com/isaacs/node-graceful-fs) in `README.md`. 
- Refactored `js` code blocks in `README.md` a bit.