### PR TITLE
Add a preserveSymlinks option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ the following:
   - `fs` (`object`, default: [`graceful-fs`](https://github.com/isaacs/node-graceful-fs)): Use this to hook into the `fs` methods or to use [`mock-fs`](https://github.com/tschaub/mock-fs)
   - `filter` (`function`, default: `undefined`): Filtering [function for Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
   - `depthLimit` (`number`, default: `undefined`): The number of times to recurse before stopping. -1 for unlimited.
-  - `preserveSymlinks` (`boolean`, default: `true`): Whether symlinks should be followed or treated as items themselves. If true, symlinks will be returned as items in their own right. If false, the linked item will be returned and potentially recursed into, in its stead.
+  - `preserveSymlinks` (`boolean`, default: `false`): Whether symlinks should be followed or treated as items themselves. If true, symlinks will be returned as items in their own right. If false, the linked item will be returned and potentially recursed into, in its stead.
 
 **Streams 1 (push) example:**
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ the following:
   - `fs` (`object`, default: [`graceful-fs`](https://github.com/isaacs/node-graceful-fs)): Use this to hook into the `fs` methods or to use [`mock-fs`](https://github.com/tschaub/mock-fs)
   - `filter` (`function`, default: `undefined`): Filtering [function for Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
   - `depthLimit` (`number`, default: `undefined`): The number of times to recurse before stopping. -1 for unlimited.
+  - `followLinks` (`boolean`, default: `false`): Whether symlinks should be followed. If false, symlinks will be returned as items in their own right. If true, the linked item will be returned, and potentially recursed into, in its stead.
 
 **Streams 1 (push) example:**
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ the following:
   - `fs` (`object`, default: [`graceful-fs`](https://github.com/isaacs/node-graceful-fs)): Use this to hook into the `fs` methods or to use [`mock-fs`](https://github.com/tschaub/mock-fs)
   - `filter` (`function`, default: `undefined`): Filtering [function for Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
   - `depthLimit` (`number`, default: `undefined`): The number of times to recurse before stopping. -1 for unlimited.
-  - `followLinks` (`boolean`, default: `false`): Whether symlinks should be followed. If false, symlinks will be returned as items in their own right. If true, the linked item will be returned, and potentially recursed into, in its stead.
+  - `preserveSymlinks` (`boolean`, default: `true`): Whether symlinks should be followed or treated as items themselves. If true, symlinks will be returned as items in their own right. If false, the linked item will be returned and potentially recursed into, in its stead.
 
 **Streams 1 (push) example:**
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function Walker (dir, options) {
     pathSorter: undefined,
     filter: undefined,
     depthLimit: undefined,
-    preserveSymlinks: true
+    preserveSymlinks: false
   }
   options = Object.assign(defaultOpts, options, defaultStreamOptions)
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,13 @@ var util = require('util')
 function Walker (dir, options) {
   assert.strictEqual(typeof dir, 'string', '`dir` parameter should be of type string. Got type: ' + typeof dir)
   var defaultStreamOptions = { objectMode: true }
-  var defaultOpts = { queueMethod: 'shift', pathSorter: undefined, filter: undefined, depthLimit: undefined }
+  var defaultOpts = {
+    queueMethod: 'shift',
+    pathSorter: undefined,
+    filter: undefined,
+    depthLimit: undefined,
+    preserveSymlinks: true
+  }
   options = Object.assign(defaultOpts, options, defaultStreamOptions)
 
   Readable.call(this, options)
@@ -23,7 +29,7 @@ Walker.prototype._read = function () {
   var self = this
   var pathItem = this.paths[this.options.queueMethod]()
 
-  var statFunction = this.options.followLinks ? self.fs.stat : self.fs.lstat
+  var statFunction = this.options.preserveSymlinks ? self.fs.lstat : self.fs.stat
 
   statFunction(pathItem, function (err, stats) {
     var item = { path: pathItem, stats: stats }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,9 @@ Walker.prototype._read = function () {
   var self = this
   var pathItem = this.paths[this.options.queueMethod]()
 
-  self.fs.lstat(pathItem, function (err, stats) {
+  var statFunction = this.options.followLinks ? self.fs.stat : self.fs.lstat
+
+  statFunction(pathItem, function (err, stats) {
     var item = { path: pathItem, stats: stats }
     if (err) return self.emit('error', err, item)
 

--- a/tests/fixtures_links.json
+++ b/tests/fixtures_links.json
@@ -1,0 +1,5 @@
+{
+  "a/b.txt": { },
+  "b": { "type": "file", "target": "./a/b.txt" },
+  "c": { "type": "dir", "target": "./a" }
+}

--- a/tests/walk_links.test.js
+++ b/tests/walk_links.test.js
@@ -1,0 +1,66 @@
+var fs = require('fs')
+var mkdirp = require('mkdirp')
+var path = require('path')
+var test = require('./_test')
+var klaw = require('../')
+var fixtures = require('./fixtures_links.json')
+
+function loadLinkFixtures (testDir) {
+  Object.keys(fixtures).forEach(function (f) {
+    var link = fixtures[f]
+    f = path.join(testDir, f)
+
+    var dir = path.dirname(f)
+    mkdirp.sync(dir)
+
+    if (link.target) {
+      fs.symlinkSync(link.target, f, link.type)
+    } else {
+      fs.writeFileSync(f, path.basename(f, path.extname(f)))
+    }
+  })
+}
+
+test('should not follow links by default', function (t, testDir) {
+  loadLinkFixtures(testDir)
+
+  var items = []
+  klaw(testDir)
+    .on('data', function (item) {
+      items.push(item.path)
+    })
+    .on('error', t.end)
+    .on('end', function () {
+      items.sort()
+      var expected = ['a', 'a/b.txt', 'b', 'c']
+      expected = expected.map(function (item) {
+        return path.join(path.join(testDir, item))
+      })
+      expected.unshift(testDir)
+
+      t.same(items, expected)
+      t.end()
+    })
+})
+
+test('should follow links if requested', function (t, testDir) {
+  loadLinkFixtures(testDir)
+
+  var items = []
+  klaw(testDir, { followLinks: true })
+    .on('data', function (item) {
+      items.push(item.path)
+    })
+    .on('error', t.end)
+    .on('end', function () {
+      items.sort()
+      var expected = ['a', 'a/b.txt', 'b', 'c', 'c/b.txt']
+      expected = expected.map(function (item) {
+        return path.join(path.join(testDir, item))
+      })
+      expected.unshift(testDir)
+
+      t.same(items, expected)
+      t.end()
+    })
+})

--- a/tests/walk_links.test.js
+++ b/tests/walk_links.test.js
@@ -47,7 +47,7 @@ test('should follow links if requested', function (t, testDir) {
   loadLinkFixtures(testDir)
 
   var items = []
-  klaw(testDir, { followLinks: true })
+  klaw(testDir, { preserveSymlinks: false })
     .on('data', function (item) {
       items.push(item.path)
     })

--- a/tests/walk_links.test.js
+++ b/tests/walk_links.test.js
@@ -21,7 +21,7 @@ function loadLinkFixtures (testDir) {
   })
 }
 
-test('should not follow links by default', function (t, testDir) {
+test('should follow links by default', function (t, testDir) {
   loadLinkFixtures(testDir)
 
   var items = []
@@ -32,7 +32,7 @@ test('should not follow links by default', function (t, testDir) {
     .on('error', t.end)
     .on('end', function () {
       items.sort()
-      var expected = ['a', 'a/b.txt', 'b', 'c']
+      var expected = ['a', 'a/b.txt', 'b', 'c', 'c/b.txt']
       expected = expected.map(function (item) {
         return path.join(path.join(testDir, item))
       })
@@ -43,18 +43,18 @@ test('should not follow links by default', function (t, testDir) {
     })
 })
 
-test('should follow links if requested', function (t, testDir) {
+test('should not follow links if requested', function (t, testDir) {
   loadLinkFixtures(testDir)
 
   var items = []
-  klaw(testDir, { preserveSymlinks: false })
+  klaw(testDir, { preserveSymlinks: true })
     .on('data', function (item) {
       items.push(item.path)
     })
     .on('error', t.end)
     .on('end', function () {
       items.sort()
-      var expected = ['a', 'a/b.txt', 'b', 'c', 'c/b.txt']
+      var expected = ['a', 'a/b.txt', 'b', 'c']
       expected = expected.map(function (item) {
         return path.join(path.join(testDir, item))
       })


### PR DESCRIPTION
Fixes #4

This keeps the existing behaviour by default to avoid breaking changes, but adds a `followLinks` option that lets you opt into link handling behaviour. The actual change is just switching between stat/lstat.

I haven't worried about handling the case where you have a link cycle. It's not especially hard to catch, but imo it's not super clear what you should do if you try to walk a cyclical filesystem, but it should be a very rare case, and it's opt-in behaviour anyway.

Only tested on Linux, but in theory it should work elsewhere just the same, and hopefully CI will confirm that for me any second now... (all looks good!)