### PR TITLE
Upgrade standard, remove standard-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "File system walker with Readable stream interface.",
   "main": "./src/index.js",
   "scripts": {
-    "lint": "standard && standard-markdown",
+    "lint": "standard",
     "test": "npm run lint && npm run unit",
     "unit": "tape tests/**/*.js | tap-spec"
   },
@@ -32,8 +32,7 @@
   "devDependencies": {
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3",
-    "standard": "^11.0.1",
-    "standard-markdown": "^4.0.1",
+    "standard": "^14.3.1",
     "tap-spec": "^5.0.0",
     "tape": "^4.2.2"
   }

--- a/tests/walk_filter.test.js
+++ b/tests/walk_filter.test.js
@@ -18,7 +18,7 @@ test('should not fire event on filtered items', function (t, testDir) {
     return path.basename(filepath) !== 'a'
   }
 
-  klaw(testDir, {filter: filter})
+  klaw(testDir, { filter: filter })
     .on('data', function (item) {
       if (fs.lstatSync(item.path).isFile()) items.push(item.path)
     })


### PR DESCRIPTION
standard-markdown doesn't allow easy async examples, since it requires wrapping them in async functions