### PR TITLE
add new option for an custom path-like object

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ the following:
   - `filter` (`function`, default: `undefined`): Filtering [function for Arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
   - `depthLimit` (`number`, default: `undefined`): The number of times to recurse before stopping. -1 for unlimited.
   - `preserveSymlinks` (`boolean`, default: `false`): Whether symlinks should be followed or treated as items themselves. If true, symlinks will be returned as items in their own right. If false, the linked item will be returned and potentially recursed into, in its stead.
+  - `pathCustom` (`path.PlatformPath`, default: `undefined`): Use this to hook into the nodejs `path` methods. For example you can set it to `path.posix` to enforce using POSIX style path instead of Windows style. 
 
 **Streams 1 (push) example:**
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,15 +16,17 @@ class Walker extends Readable {
       filter: undefined,
       depthLimit: undefined,
       preserveSymlinks: false,
+      pathCustom: undefined,
       ...options,
       objectMode: true
     }
 
     super(options)
-    this.root = path.resolve(dir)
+    this.pathCustom = options.pathCustom || path
+    this.root = this.pathCustom.resolve(dir)
     this.paths = [this.root]
     this.options = options
-    if (options.depthLimit > -1) { this.rootDepth = this.root.split(path.sep).length + 1 }
+    if (options.depthLimit > -1) { this.rootDepth = this.root.split(this.pathCustom.sep).length + 1 }
     this.fs = options.fs || fs
   }
 
@@ -39,7 +41,7 @@ class Walker extends Readable {
       if (err) { return this.emit('error', err, item) }
 
       if (!stats.isDirectory() || (this.rootDepth &&
-        pathItem.split(path.sep).length - this.rootDepth >= this.options.depthLimit)) {
+        pathItem.split(this.pathCustom.sep).length - this.rootDepth >= this.options.depthLimit)) {
         return this.push(item)
       }
 
@@ -48,8 +50,9 @@ class Walker extends Readable {
           this.push(item)
           return this.emit('error', err, item)
         }
+        const pathCustom = this.pathCustom;
 
-        pathItems = pathItems.map(function (part) { return path.join(pathItem, part) })
+        pathItems = pathItems.map(function (part) { return pathCustom.join(pathItem, part) })
         if (this.options.filter) { pathItems = pathItems.filter(this.options.filter) }
         if (this.options.pathSorter) { pathItems.sort(this.options.pathSorter) }
         // faster way to do do incremental batch array pushes


### PR DESCRIPTION
Sometimes we may work for a different fs, which requires different `path.sep` or `path.join()`.

For instance, I am developing a nodejs program on windows, 
but the program is expected to be run on an linux.
Then I need to inject [`path.posix`](https://nodejs.org/api/path.html#path_path_posix), 
instead of using the vanilla `path`, so that the results are returned as '/xxx/yyy` instead of `C:\\xxx\yyy`.

It's far more flexible if klaw allowing setting a "mocked path object". :-)